### PR TITLE
Ensure that ongoing services with an unknown EndDate are available in…

### DIFF
--- a/R/transxchange_import6.R
+++ b/R/transxchange_import6.R
@@ -74,7 +74,7 @@ transxchange_import <- function(file, run_debug = TRUE, full_import = FALSE) {
   # Sometime end date is missing in which case assume service runs for one year
   Services_main$EndDate <- dplyr::if_else(
     is.na(Services_main$EndDate),
-    as.character(lubridate::ymd(Services_main$StartDate) + 365),
+    as.character(max(lubridate::ymd(Services_main$StartDate), lubridate::today()) + lubridate::days(365)),
     as.character(Services_main$EndDate)
   )
 

--- a/R/transxchange_import6.R
+++ b/R/transxchange_import6.R
@@ -70,11 +70,17 @@ transxchange_import <- function(file, run_debug = TRUE, full_import = FALSE) {
   SpecialDaysOperation <- Services$SpecialDaysOperation
   rm(Services)
 
-  # Handel NA in service date
-  # Sometime end date is missing in which case assume service runs for one year
+  # Handle NA in service date
+  # Sometimes end date is missing in which case assume service runs for one year
+
+  CreationDate <- as.Date(lubridate::ymd_hms(xml2::xml_attr(xml, "CreationDateTime")))
+  ModifiedDate <- as.Date(lubridate::ymd_hms(xml2::xml_attr(xml, "ModificationDateTime")))
+
   Services_main$EndDate <- dplyr::if_else(
     is.na(Services_main$EndDate),
-    as.character(max(lubridate::ymd(Services_main$StartDate), lubridate::today()) + lubridate::days(365)),
+    as.character(
+      max(lubridate::ymd(Services_main$StartDate), CreationDate, ModifiedDate, na.rm=TRUE) + 
+       lubridate::days(365)),
     as.character(Services_main$EndDate)
   )
 


### PR DESCRIPTION
… the immediate future.

Services may run for long time unchanged. A current example of this is the Celtic Coaches X47 (Wales), with an `OperatingPeriod StartDate` of 2020-06-29 and no defined `EndDate`.

The proposed change should ensure that future services are available for a year after they start, and that current services are available for a year from the time of import.