### PR TITLE
ATOC: Use public, rather than scheduled, times by default with ATOC data

### DIFF
--- a/R/atoc.R
+++ b/R/atoc.R
@@ -149,8 +149,8 @@ atoc2gtfs <- function(path_in,
   # rm(alf, flf, mca, msn)
 
   stop_times <- stop_times[, c(
-    "Scheduled Arrival Time",
-    "Scheduled Departure Time",
+    "Arrival Time",
+    "Departure Time",
     "Location", "stop_sequence",
     "Activity", "rowID", "schedule"
   )]

--- a/R/atoc_nr.R
+++ b/R/atoc_nr.R
@@ -91,8 +91,8 @@ nr2gtfs <- function(path_in,
   # rm(alf, flf, mca, msn)
 
   stop_times <- stop_times[, c(
-    "Scheduled Arrival Time",
-    "Scheduled Departure Time",
+    "Arrival Time",
+    "Departure Time",
     "Location", "stop_sequence",
     "Activity", "rowID", "schedule"
   )]

--- a/man/importMCA.Rd
+++ b/man/importMCA.Rd
@@ -4,7 +4,13 @@
 \alias{importMCA}
 \title{Import the .mca file}
 \usage{
-importMCA(file, silent = TRUE, ncores = 1, full_import = FALSE)
+importMCA(
+  file,
+  silent = TRUE,
+  ncores = 1,
+  full_import = FALSE,
+  working_timetable = FALSE
+)
 }
 \arguments{
 \item{file}{Path to .mca file}
@@ -14,6 +20,8 @@ importMCA(file, silent = TRUE, ncores = 1, full_import = FALSE)
 \item{ncores}{number of cores to use when paralell processing}
 
 \item{full_import}{import all data, default FALSE}
+
+\item{working_timetable}{use rail industry scheduling times instead of public times}
 }
 \description{
 Import the .mca file


### PR DESCRIPTION
Addresses https://github.com/ITSLeeds/UK2GTFS/issues/34 .

Seems to be working for me with Wales-ish data! Function supports using rail industry times with the `working_timetable` argument.