### PR TITLE
Force fix to Stagecoach agency

### DIFF
--- a/R/gtfs_merge.R
+++ b/R/gtfs_merge.R
@@ -48,6 +48,7 @@ gtfs_merge <- function(gtfs_list, force = FALSE) {
   agency$agency_name[agency$agency_name == "Edward Bros"] <- "Edwards Bros"
   agency$agency_name[agency$agency_name == "John`s Coaches"] <- "John's Coaches"
   agency$agency_name[agency$agency_name == "Stagecoach in Lancaster."] <- "Stagecoach in Lancashire"
+  agency$agency_name[agency$agency_name == "Stagecoach in South Wales"] <- "Stagecoach South Wales"
 
   # fix duplicated agency_ids - special cases
   #agency$agency_id[agency$agency_name == "Tanat Valley Coaches"] <- "TanVaCo"


### PR DESCRIPTION
Stagecoach (in) South Wales is currently providing files with two different operator names: "Stagecoach in South Wales" and "Stagecoach South Wales". I'd guess that they're moving from the former from the latter.

I'm guessing the proposed fix isn't really a sustainable approach to these sorts of issues - understand entirely if you reject this PR!