### PR TITLE
Human names

### DIFF
--- a/R/atoc.R
+++ b/R/atoc.R
@@ -190,6 +190,7 @@ atoc2gtfs <- function(path_in,
   # Main Timetable Build
   timetables <- schedule2routes(
     stop_times = stop_times,
+    stops = stops,
     schedule = schedule,
     silent = silent,
     ncores = ncores

--- a/R/atoc_export.R
+++ b/R/atoc_export.R
@@ -313,15 +313,24 @@ longnames <- function(routes, stop_times, stops) {
   stop_times_sub <- dplyr::group_by(stop_times, trip_id)
   stop_times_sub <- dplyr::summarise(stop_times_sub,
     schedule = unique(schedule),
-    stop_a = stop_id[stop_sequence == 1],
+    stop_id_a = stop_id[stop_sequence == 1],
     # seq = min(stop_sequence),
-    stop_b = stop_id[stop_sequence == max(stop_sequence)]
+    stop_id_b = stop_id[stop_sequence == max(stop_sequence)]
+  )
+
+  # Look-up the stop_names field from stop_id_a and stop_id_b
+  # in stops and put that into stop_name_a and stop_name_b
+  stop_times_sub <- dplyr::merge(
+    stop_times_sub,
+    stops[, c("stop_id", "stop_name")],
+    by = c("stop_id_a", "stop_id_b"),
+    all.x = TRUE
   )
 
   stop_times_sub$route_long_name <- paste0("From ",
-                                           stops[stops$stop_id == stop_times_sub$stop_a]$stop_name,
+                                           stop_times_sub$stop_name_a,
                                            " to ",
-                                           stops[stops$stop_id == stop_times_sub$stop_b]$stop_name)
+                                           stop_times_sub$stop_name_b)
 
   stop_times_sub$route_long_name <- gsub(" Rail Station", "" , stop_times_sub$route_long_name)
 

--- a/R/atoc_export.R
+++ b/R/atoc_export.R
@@ -319,9 +319,9 @@ longnames <- function(routes, stop_times, stops) {
   )
 
   stop_times_sub$route_long_name <- paste0("From ",
-                                           stops[stop_id == stop_times_sub$stop_a]$stop_name,
+                                           stops[stops$stop_id == stop_times_sub$stop_a]$stop_name,
                                            " to ",
-                                           stops[stop_id == stop_times_sub$stop_b]$stop_name)
+                                           stops[stops$stop_id == stop_times_sub$stop_b]$stop_name)
 
   stop_times_sub$route_long_name <- gsub(" Rail Station", "" , stop_times_sub$route_long_name)
 

--- a/R/atoc_export.R
+++ b/R/atoc_export.R
@@ -302,7 +302,7 @@ checkrows <- function(tmp) {
 #' internal function for contructing longnames of routes
 #'
 #' @details
-#' creates the long name of a route from appopriate variaibles
+#' creates the long name of a route from appropriate variaibles
 #'
 #' @param routes routes data.frame
 #' @param stop_times stop_times data.frame
@@ -349,7 +349,7 @@ longnames <- function(routes, stop_times, stops) {
 #' @details
 #' split overlapping start and end dates
 #'
-#' @param schedule scheduel data.frame
+#' @param schedule schedule data.frame
 #' @param ncores number of processes for parallel processing (default = 1)
 #' @noRd
 #'

--- a/R/atoc_export.R
+++ b/R/atoc_export.R
@@ -318,13 +318,16 @@ longnames <- function(routes, stop_times, stops) {
     stop_id_b = stop_id[stop_sequence == max(stop_sequence)]
   )
 
-  # Look-up the stop_names field from stop_id_a and stop_id_b
-  # in stops and put that into stop_name_a and stop_name_b
+  # Add names for `stop_id_[a|b]` as `stop_name_[a|b]`
   stop_times_sub <- dplyr::left_join(
     stop_times_sub,
-    stops[, c("stop_id", "stop_name")],
-    by = c("stop_id_a", "stop_id_b"),
-    all.x = TRUE
+    rename(stops[, c("stop_id", "stop_name")], stop_name_a = stop_name),
+    by = c("stop_id_a" = "stop_id")
+  )
+  stop_times_sub <- dplyr::left_join(
+    stop_times_sub,
+    rename(stops[, c("stop_id", "stop_name")], stop_name_b = stop_name),
+    by = c("stop_id_b" = "stop_id")
   )
 
   stop_times_sub$route_long_name <- paste0("From ",

--- a/R/atoc_export.R
+++ b/R/atoc_export.R
@@ -321,14 +321,12 @@ longnames <- function(routes, stop_times, stops) {
   # Add names for `stop_id_[a|b]` as `stop_name_[a|b]`
   stop_times_sub <- dplyr::left_join(
     stop_times_sub,
-    rename(stops[, c("stop_id", "stop_name")], stop_name_a = stop_name),
-    by = c("stop_id_a" = "stop_id")
-  )
+    dplyr::rename(stops[, c("stop_id", "stop_name")], stop_name_a = stop_name),
+    by = c("stop_id_a" = "stop_id"))
   stop_times_sub <- dplyr::left_join(
     stop_times_sub,
-    rename(stops[, c("stop_id", "stop_name")], stop_name_b = stop_name),
-    by = c("stop_id_b" = "stop_id")
-  )
+    dplyr::rename(stops[, c("stop_id", "stop_name")], stop_name_b = stop_name),
+    by = c("stop_id_b" = "stop_id"))
 
   stop_times_sub$route_long_name <- paste0("From ",
                                            stop_times_sub$stop_name_a,

--- a/R/atoc_export.R
+++ b/R/atoc_export.R
@@ -320,7 +320,7 @@ longnames <- function(routes, stop_times, stops) {
 
   # Look-up the stop_names field from stop_id_a and stop_id_b
   # in stops and put that into stop_name_a and stop_name_b
-  stop_times_sub <- dplyr::merge(
+  stop_times_sub <- dplyr::left_join(
     stop_times_sub,
     stops[, c("stop_id", "stop_name")],
     by = c("stop_id_a", "stop_id_b"),

--- a/R/atoc_export.R
+++ b/R/atoc_export.R
@@ -299,7 +299,6 @@ checkrows <- function(tmp) {
   }
 }
 
-# TODO: make mode affect name
 #' internal function for contructing longnames of routes
 #'
 #' @details
@@ -307,9 +306,10 @@ checkrows <- function(tmp) {
 #'
 #' @param routes routes data.frame
 #' @param stop_times stop_times data.frame
+#' @param stops stops data.frame
 #' @noRd
 #'
-longnames <- function(routes, stop_times) {
+longnames <- function(routes, stop_times, stops) {
   stop_times_sub <- dplyr::group_by(stop_times, trip_id)
   stop_times_sub <- dplyr::summarise(stop_times_sub,
     schedule = unique(schedule),
@@ -318,10 +318,13 @@ longnames <- function(routes, stop_times) {
     stop_b = stop_id[stop_sequence == max(stop_sequence)]
   )
 
-  stop_times_sub$route_long_name <- paste0("Train from ",
-                                           stop_times_sub$stop_a,
+  stop_times_sub$route_long_name <- paste0("From ",
+                                           stops[stop_id == stop_times_sub$stop_a]$stop_name,
                                            " to ",
-                                           stop_times_sub$stop_b)
+                                           stops[stop_id == stop_times_sub$stop_b]$stop_name)
+
+  stop_times_sub$route_long_name <- gsub(" Rail Station", "" , stop_times_sub$route_long_name)
+
   stop_times_sub <- stop_times_sub[!duplicated(stop_times_sub$schedule), ]
   stop_times_sub <- stop_times_sub[, c("schedule", "route_long_name")]
 

--- a/R/atoc_import.R
+++ b/R/atoc_import.R
@@ -17,7 +17,7 @@ importALF <- function(file) {
     stringsAsFactors = FALSE
   )
 
-  # Now Fix Misaigned Values
+  # Now Fix Misaligned Values
   # Check each column for misalignments
   checkCol <- function(x, val) {
     checkCol.inner <- function(x, val) {

--- a/R/atoc_main.R
+++ b/R/atoc_main.R
@@ -122,7 +122,9 @@ schedule2routes <- function(stop_times, schedule, silent = TRUE, ncores = 1) {
 
   routes <- routes[, c("route_id", "route_type", "ATOC Code", "route_long_name")]
   names(routes) <- c("route_id", "route_type", "agency_id", "route_long_name")
-  routes$route_short_name <- routes$route_id
+
+  # IDs are not meaningful, just leave out
+  # routes$route_short_name <- routes$route_id
 
   routes$route_type[routes$agency_id == "LT"] <- 1 # London Underground is Metro
 

--- a/R/atoc_main.R
+++ b/R/atoc_main.R
@@ -4,12 +4,13 @@
 #' Export ATOC schedule as GTFS
 #'
 #' @param stop_times stop-times
+#' @param stops stops data.frame
 #' @param schedule list of dataframes
 #' @param silent logical
 #' @param ncores number of cores to use
 #' @noRd
 #'
-schedule2routes <- function(stop_times, schedule, silent = TRUE, ncores = 1) {
+schedule2routes <- function(stop_times, stops, schedule, silent = TRUE, ncores = 1) {
 
 
   ### SECTION 1: ###############################################################################
@@ -93,7 +94,7 @@ schedule2routes <- function(stop_times, schedule, silent = TRUE, ncores = 1) {
   # make make the trips.txt  file by matching the calnedar to the stop_times
 
   trips <- calendar[, c("service_id", "trip_id", "rowID", "ATOC Code", "Train Status")]
-  trips <- longnames(routes = trips, stop_times = stop_times)
+  trips <- longnames(routes = trips, stop_times = stop_times, stops = stops)
 
   ### SECTION 4: ###############################################################################
   # make make the routes.txt

--- a/R/atoc_main.R
+++ b/R/atoc_main.R
@@ -81,7 +81,7 @@ schedule2routes <- function(stop_times, stops, schedule, silent = TRUE, ncores =
 
 
   ### SECTION 3: ###############################################################################
-  # When splitting the calendar roWIDs are duplicated
+  # When splitting the calendar rowIDs are duplicated
   # so create new system of trip_ids and duplicate the relevant stop_times
   if (!silent) {
     message(paste0(Sys.time(), " Duplicating necessary stop times"))
@@ -91,15 +91,15 @@ schedule2routes <- function(stop_times, stops, schedule, silent = TRUE, ncores =
   stop_times <- duplicate.stop_times_alt(calendar = calendar, stop_times = stop_times, ncores = 1)
 
   ### SECTION 5: ###############################################################################
-  # make make the trips.txt  file by matching the calnedar to the stop_times
+  # make the trips.txt file by matching the calendar to the stop_times
 
   trips <- calendar[, c("service_id", "trip_id", "rowID", "ATOC Code", "Train Status")]
   trips <- longnames(routes = trips, stop_times = stop_times, stops = stops)
 
   ### SECTION 4: ###############################################################################
-  # make make the routes.txt
+  # make the routes.txt
   # a route is all the trips with a common start and end
-  # i.e. scheduels original UID
+  # i.e. schedules original UID
   if (!silent) {
     message(paste0(Sys.time(), " Building routes.txt"))
   }

--- a/R/atoc_main.R
+++ b/R/atoc_main.R
@@ -124,7 +124,7 @@ schedule2routes <- function(stop_times, schedule, silent = TRUE, ncores = 1) {
   names(routes) <- c("route_id", "route_type", "agency_id", "route_long_name")
 
   # IDs are not meaningful, just leave out
-  # routes$route_short_name <- routes$route_id
+  routes$route_short_name <- "" # was: routes$route_id
 
   routes$route_type[routes$agency_id == "LT"] <- 1 # London Underground is Metro
 

--- a/R/atoc_nr.R
+++ b/R/atoc_nr.R
@@ -106,6 +106,7 @@ nr2gtfs <- function(path_in,
   # Main Timetable Build
   timetables <- schedule2routes(
     stop_times = stop_times,
+    stops = stops,
     schedule = schedule,
     silent = silent,
     ncores = ncores

--- a/R/gtfs_compress.R
+++ b/R/gtfs_compress.R
@@ -5,7 +5,7 @@
 #' @details by default UK2GTFS trys to preserve id numbers during the conversion
 #'   process to allow back comparions to the original files, e.g.
 #'   `transxchange2gtfs()` retains stop ids from the NAPTAN. However this means
-#'   files sizes are increased. This fucntion replaces ids with intergers and
+#'   files sizes are increased. This fucntion replaces ids with integers and
 #'   thus reduces the size of the gtfs file.
 #'
 #' @export

--- a/R/gtfs_split.R
+++ b/R/gtfs_split.R
@@ -1,8 +1,8 @@
 #' Split a GTFS object
 #'
-#' For large regions GTFS fiels can get very big. THis fucntion splits a GTFS
+#' For large regions GTFS files can get very big. This fucntion splits a GTFS
 #' object into a list of GTFS objects. It tries to balance the sizes of the
-#' objects. Splits are made by agency_id so maximumd number of splits equalts
+#' objects. Splits are made by agency_id so maximum number of splits equals
 #' the number of unique agency_ids.
 #'
 #' @param gtfs a gtfs object

--- a/R/gtfs_subset.R
+++ b/R/gtfs_subset.R
@@ -2,7 +2,7 @@
 #'
 #' Clips the GTFS file to only include stops within the bounds object, trips
 #' that cross the bouundary of the the object are truncated. Any trips that stop
-#' only once in the bounds are removed completly.
+#' only once in the bounds are removed completely.
 #'
 #' @param gtfs a gtfs object
 #' @param bounds an sf data frame of polygons or multipolygons with CRS 4326


### PR DESCRIPTION
Changes:
- Remove IDs from `route_short_name`, make it empty instead
- Replace stop codes with stop names in `route_long_name`
- Remove "Train" from `route_long_name`; consumers can add that from the route type, if needed
- Fix typos in some comments