### PR TITLE
Performance + Verbosity of validation + thoroughness of fixing

### DIFF
--- a/R/atoc_export.R
+++ b/R/atoc_export.R
@@ -392,10 +392,10 @@ makeCalendar <- function(schedule, ncores = 1) {
   }
 
   res.calendar <- lapply(res, `[[`, 1)
-  res.calendar <- data.table::rbindlist(res.calendar, use.names=FALSE) #res.calendar <- dplyr::bind_rows(res.calendar) #performance, was taking 10 minutes to execute the bind_rows
+  res.calendar <- data.table::rbindlist(res.calendar, use.names=FALSE) #performance, was taking 10 minutes to execute bind_rows
   res.calendar_dates <- lapply(res, `[[`, 2)
   res.calendar_dates <- res.calendar_dates[!is.na(res.calendar_dates)]
-  res.calendar_dates <- data.table::rbindlist(res.calendar_dates, use.names=FALSE) #dplyr::bind_rows(res.calendar_dates) performance
+  res.calendar_dates <- data.table::rbindlist(res.calendar_dates, use.names=FALSE)
 
   days <- lapply(res.calendar$Days, function(x) {
     as.integer(substring(x, 1:7, 1:7))
@@ -409,7 +409,7 @@ makeCalendar <- function(schedule, ncores = 1) {
 
   message(paste0(
     Sys.time(),
-    " Removing trips that only occur on days of the week that are non-operational"
+    " Removing trips that only occur on days of the week that are outside the timetable validity period"
   ))
 
   #res.calendar.split <- split(res.calendar, seq(1, nrow(res.calendar)))
@@ -578,7 +578,7 @@ duplicate.stop_times_alt <- function(calendar, stop_times, ncores = 1) {
 
   # stop_times.dup = stop_times.dup[order(stop_times.dup$rowID),]
 
-  stop_times.comb <- rbind(stop_times, stop_times.dup)
+  stop_times.comb <- data.table::rbindlist(list(stop_times, stop_times.dup), use.names=FALSE)
 
   return(stop_times.comb)
 }

--- a/R/gtfs_cleaning.R
+++ b/R/gtfs_cleaning.R
@@ -225,9 +225,16 @@ gtfs_clean <- function(gtfs, removeNonPublic =  FALSE) {
     joinedTrips <- merge(gtfs$trips, gtfs$routes, by = "route_id", all.x = TRUE)
 
     joinedCalls <- merge(gtfs$stop_times, joinedTrips, by = "trip_id", all.x = TRUE)
-
     filteredCalls <- joinedCalls[ !is.na( joinedCalls$route_type ), ]
     gtfs$stop_times <- filteredCalls[, names( gtfs$stop_times )]
+
+    joinedCalendar <- merge(gtfs$calendar, joinedTrips, by = "service_id", all.x = TRUE)
+    filteredCalendar <- joinedCalendar[ !is.na( joinedCalendar$route_type ), ]
+    gtfs$calendar <- filteredCalendar[, names( gtfs$calendar )]
+
+    joinedCalendarDates <- merge(gtfs$calendar_dates, joinedTrips, by = "service_id", all.x = TRUE)
+    filteredCalendarDates <- joinedCalendarDates[ !is.na( joinedCalendarDates$route_type ), ]
+    gtfs$calendar_dates <- filteredCalendarDates[, names( gtfs$calendar_dates )]
 
     filteredTrips <- joinedTrips[ !is.na( joinedTrips$route_type ), ]
     gtfs$trips <- filteredTrips[, names( gtfs$trips )]

--- a/R/gtfs_validate.R
+++ b/R/gtfs_validate.R
@@ -235,21 +235,29 @@ gtfs_validate_external <- function(path_gtfs, path_validator) {
 #' @details
 #' Actions performed
 #' 1. Remove stops with missing location
-#' 2. Remove stops from stop_times that are not in stops
-#' 3. Remove trips from stop_times that are not in trips
+#' 2. Remove routes that don't exist in agency
+#' 3. Remove trips that don't exist in routes
+#' 4. Remove stop_times(calls) that don't exist in trips
+#' 5. Remove stop_times(calls) that don't exist in stops
 #'
 #' @export
 gtfs_force_valid <- function(gtfs) {
   message("This function does not fix problems it just removes them")
 
-  # Stops with missing lat/lon
+  # 1. Stops with missing lat/lon
   gtfs$stops <- gtfs$stops[!is.na(gtfs$stops$stop_lon) & !is.na(gtfs$stops$stop_lat),]
 
-  # Stop Times that are not in stops
-  gtfs$stop_times <- gtfs$stop_times[gtfs$stop_times$stop_id %in%  gtfs$stops$stop_id,]
+  # 2. Routes that have agency_id that doesn't exist in agency
+  gtfs$routes <- gtfs$routes[gtfs$routes$agency_id %in%  gtfs$agency$agency_id,]
 
-  #Trips that are not in trips
+  # 3. Trips that have route_id that doesn't exist in route
+  gtfs$trips <- gtfs$trips[gtfs$trips$route_id %in%  gtfs$routes$route_id,]
+
+  # 4. Stop Times that have trip_id that doesn't exist in trips
   gtfs$stop_times <- gtfs$stop_times[gtfs$stop_times$trip_id %in% gtfs$trips$trip_id,]
+
+  # 5. Stop Times that have stops_id that doesn't exist in stops
+  gtfs$stop_times <- gtfs$stop_times[gtfs$stop_times$stop_id %in%  gtfs$stops$stop_id,]
 
   return(gtfs)
 }

--- a/R/gtfs_validate.R
+++ b/R/gtfs_validate.R
@@ -239,6 +239,8 @@ gtfs_validate_external <- function(path_gtfs, path_validator) {
 #' 3. Remove trips that don't exist in routes
 #' 4. Remove stop_times(calls) that don't exist in trips
 #' 5. Remove stop_times(calls) that don't exist in stops
+#' 6. Remove Calendar that have service_id that doesn't exist in trips
+#' 7. Remove Calendar_dates that have service_id that doesn't exist in trips
 #'
 #' @export
 gtfs_force_valid <- function(gtfs) {
@@ -258,6 +260,12 @@ gtfs_force_valid <- function(gtfs) {
 
   # 5. Stop Times that have stops_id that doesn't exist in stops
   gtfs$stop_times <- gtfs$stop_times[gtfs$stop_times$stop_id %in%  gtfs$stops$stop_id,]
+
+  # 6. Calendar that have service_id that doesn't exist in trip
+  gtfs$calendar <- gtfs$calendar[gtfs$calendar$service_id %in%  gtfs$trips$service_id,]
+
+  # 7. Calendar_dates that have service_id that doesn't exist in trip
+  gtfs$calendar_dates <- gtfs$calendar_dates[gtfs$calendar_dates$service_id %in%  gtfs$trips$service_id,]
 
   return(gtfs)
 }

--- a/R/gtfs_validate.R
+++ b/R/gtfs_validate.R
@@ -95,7 +95,8 @@ gtfs_validate_internal <- function(gtfs) {
   }
 
   if (any(duplicated(gtfs$trips$trip_id))) {
-    warning("Duplicated trip_id in trips")
+    warning("Duplicated trip_id in trips:")
+    warning(gtfs$trips$trip_id[duplicated(gtfs$trips$trip_id)])
   }
 
   # stop_times
@@ -177,32 +178,44 @@ gtfs_validate_internal <- function(gtfs) {
 
   # Check for missing values
   if (!all(gtfs$routes$agency_id %in% gtfs$agency$agency_id)) {
-    warning("Unknown agency_id in routes")
+    unknown = unique(gtfs$routes$agency_id[!(gtfs$routes$agency_id %in% gtfs$agency$agency_id)])
+    warning("Unknown agency_id in routes: (", length(unknown), ") ", paste(unknown, collapse=" ") )
   }
 
   if (!all(gtfs$stop_times$trip_id %in% gtfs$trips$trip_id)) {
-    warning("Unknown trip_id in stop_times")
+    unknown = unique(gtfs$stop_times$trip_id[!(gtfs$stop_times$trip_id %in% gtfs$trips$trip_id)])
+    warning("Unknown trip_id in stop_times: (", length(unknown), ") values:")
+    warning( paste(unknown, collapse=" ") )
   }
 
   if (!all(gtfs$stop_times$stop_id %in% gtfs$stops$stop_id)) {
-    warning("Unknown stop_id in stop_times")
+    unknown = unique(gtfs$stop_times$stop_id[!(gtfs$stop_times$stop_id %in% gtfs$stops$stop_id)])
+    warning("Unknown stop_id in stop_times: (", length(unknown), ") values: (TIPLOC data may need refreshing)")
+    warning( paste(unknown, collapse=" ") )
   }
 
   # Duplicated IDs
   if (any(duplicated(gtfs$agency$agency_id))) {
-    warning("Duplicated agency_id in agency")
+    unknown = unique(gtfs$agency$agency_id[duplicated(gtfs$agency$agency_id)])
+    warning("Duplicated agency_id in agency: (", length(unknown), ") ", paste(unknown, collapse=" ") )
   }
 
   if (any(duplicated(gtfs$stops$stop_id))) {
-    warning("Duplicated stop_id in stops")
+    unknown = unique(gtfs$stops$stop_id[duplicated(gtfs$stops$stop_id)])
+    warning("Duplicated stop_id in stops: (", length(unknown), ") values:")
+    warning( paste(unknown, collapse=" ") )
   }
 
   if (any(duplicated(gtfs$trips$trip_id))) {
-    warning("Duplicated trip_id in trips")
+    unknown = unique(gtfs$trips$trip_id[duplicated(gtfs$trips$trip_id)])
+    warning("Duplicated trip_id in trips: (", length(unknown), ") values:")
+    warning( paste(unknown, collapse=" "))
   }
 
   if (any(duplicated(gtfs$routes$route_id))) {
-    warning("Duplicated route_id in routes")
+    unknown = unique(gtfs$routes$route_id[duplicated(gtfs$routes$route_id)])
+    warning("Duplicated route_id in routes: (", length(unknown), ") values:")
+    warning( paste(unknown, collapse=" "))
   }
 
 


### PR DESCRIPTION
>performance: change call from bind to use data.table
>verbosity: write to console details of the data causing problems during check
>cleaning: add option to remove 'non-public' services (null route_type) so that the resulting data can load into OTP (and projects like OTP4GB without error)
>fixing: be more thorough at maintaining referential integrity of output data e.g. ensure that if an agency is missing, data for that agency is removed. 

See individual commits for more detail