### PR TITLE
explicitly namespace dopar transxchange try calls

### DIFF
--- a/R/transxchange.R
+++ b/R/transxchange.R
@@ -142,7 +142,7 @@ transxchange2gtfs <- function(path_in,
     doSNOW::registerDoSNOW(cl)
     boot <- foreach::foreach(i = seq_len(length(files)), .options.snow = opts)
     res_all <- foreach::`%dopar%`(boot, {
-      transxchange_import_try(files[i],
+        UK2GTFS:::transxchange_import_try(files[i],
                               try_mode = try_mode)
     })
     parallel::stopCluster(cl)
@@ -180,7 +180,7 @@ transxchange2gtfs <- function(path_in,
     doSNOW::registerDoSNOW(cl)
     boot <- foreach::foreach(i = seq_len(length(res_all)), .options.snow = opts)
     gtfs_all <- foreach::`%dopar%`(boot, {
-      transxchange_export_try(res_all[[i]],
+        UK2GTFS:::transxchange_export_try(res_all[[i]],
                           cal = cal,
                           naptan = naptan_trim,
                           scotland = scotland,


### PR DESCRIPTION
@mem48 Thanks for this awesome package! This PR fixes a bug that will affect some systems (including mine, on which the main functions do not work). The workers spawned by `dopar` calls won't necessarily have the package loaded, dependent on complex interactions between OS and multi-threading libraries, so it's always important to explicitly namespace functions called. Your calls here are to internal functions, which require `:::` notation, but as I guess this package is not intended to get to CRAN (right?), that should be acceptable. Happy to discuss alternatives if you prefer.