### PR TITLE
Set route_short_name to destination name

### DIFF
--- a/R/atoc_export.R
+++ b/R/atoc_export.R
@@ -174,8 +174,16 @@ longnames <- function(routes, stop_times, stops) {
 
   stop_times_sub$route_long_name <- gsub(" Rail Station", "" , stop_times_sub$route_long_name)
 
+  # Set route_short_name to destination name
+  stop_times_sub$route_short_name <- ifelse(
+    is.na(stop_times_sub$stop_name_b),
+    stop_times_sub$stop_id_b,
+    stop_times_sub$stop_name_b
+  )
+  stop_times_sub$route_short_name <- gsub(" Rail Station", "", stop_times_sub$route_short_name)
+
   stop_times_sub <- stop_times_sub[!duplicated(stop_times_sub$schedule), ]
-  stop_times_sub <- stop_times_sub[, c("schedule", "route_long_name")]
+  stop_times_sub <- stop_times_sub[, c("schedule", "route_long_name", "route_short_name")]
 
   routes <- dplyr::left_join(routes, stop_times_sub,
                              by = c("rowID" = "schedule"))

--- a/R/atoc_main.R
+++ b/R/atoc_main.R
@@ -133,18 +133,16 @@ schedule2routes <- function(stop_times, stops, schedule, silent = TRUE, ncores =
 
   routes <- trips
 
-  routes <- dplyr::group_by(routes, `ATOC Code`, route_long_name, `Train Category`, route_type )
+  routes <- dplyr::group_by(routes, `ATOC Code`, route_long_name, route_short_name, `Train Category`, route_type )
   routes <- dplyr::summarise(routes)
   routes$route_id <- 1:nrow(routes)
 
   #join route_id back into trip table
-  trips <- dplyr::left_join(trips, routes, by = c("ATOC Code", "route_long_name", "Train Category", "route_type"))
+  trips <- dplyr::left_join(trips, routes, by = c("ATOC Code", "route_long_name", "route_short_name", "Train Category", "route_type"))
 
-  routes <- routes[, c("route_id", "route_type", "ATOC Code", "route_long_name", "Train Category" )]
-  names(routes) <- c("route_id", "route_type", "agency_id", "route_long_name", "train_category" )
+  routes <- routes[, c("route_id", "route_type", "ATOC Code", "route_short_name", "route_long_name", "Train Category" )]
+  names(routes) <- c("route_id", "route_type", "agency_id", "route_short_name", "route_long_name", "train_category" )
 
-  # IDs are not meaningful, just leave out
-  routes$route_short_name <- "" # was: routes$route_id
 
 
   ### Section 6: #######################################################


### PR DESCRIPTION
For example, route_long_name "Train from Glasgow Queen Street to
Inverness" and route_short_name "Inverness"

I wanted something shorter than the long name for my project, so
I arbitrarily picked the destination station because it's what
I've seen on information displays.
